### PR TITLE
install pyreadr in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,4 @@ RUN chown -R ${NB_UID} ${HOME}
 # add modification code here
 
 USER ${NB_USER}
-RUN pip install cvxpy
-RUN pip install altair
+RUN pip install altair pyreadr


### PR DESCRIPTION
- Removed CVXPY since it is not needed
- Installed pyreadr in Dockerfile since Binder session doesn't seem to have internet connection from inside the session
- You can view the diff of the notebook in Jupyter Lab